### PR TITLE
Fix `SOURCE_DIR_MAP` mismatch for PubMed source category

### DIFF
--- a/data/processing/split.py
+++ b/data/processing/split.py
@@ -41,8 +41,7 @@ SOURCE_CAPS = {
 # for tokenizer training. Bookshelf and CDC use source_category="educational"
 # so they naturally map to the existing educational directory.
 SOURCE_DIR_MAP = {
-    "research_papers": "pubmed",
-    "biomedical_research": "pubmed_abstracts",
+    "biomedical_research": "pubmed",
     "clinical_trials": "clinical_trials",
     "regulatory": "fda",
     "educational": "educational",


### PR DESCRIPTION
## Summary

This PR fixes a source category mismatch in `split.py` where `SOURCE_DIR_MAP` contained a dead `"research_papers"` entry never emitted by any scraper, and mapped `"biomedical_research"` to the wrong output directory.

## Related issues or PRs

- Resolves issue #1

## Changes made

- Removed unreachable `"research_papers": "pubmed"` entry from `SOURCE_DIR_MAP` (no scraper emits this category)
- Changed `"biomedical_research"` mapping from `"pubmed_abstracts"` to `"pubmed"` to match the intended output directory

## Technical implementation

- **Approach:** Both `PubMedScraper` and `PubMedAbstractsScraper` emit `source_category = "biomedical_research"`. They are all PubMed-sourced biomedical content, so a single `"pubmed"` output directory is appropriate. The distinction between full papers and abstracts is a scraping detail, not a meaningful corpus category.
- **Key files modified:** `data/processing/split.py`
- **Dependencies added/removed:** None
- **Design patterns used:** N/A

## Testing performed

- [x] Code follows project conventions and patterns (PEP 8, type hints where helpful).
- [x] No hardcoded values (use constants/configuration).
- [x] No debugging code or print statements left in.
- [x] Removed unused imports, variables, and files.

## Code quality

- [x] Code follows project conventions and patterns (PEP 8, type hints where helpful).
- [x] No hardcoded values (use constants/configuration).
- [x] No debugging code or print statements left in.
- [x] Removed unused imports, variables, and files.

## Additional context

Low-impact fix — only affects per-document output file directory naming. The concatenated `train.txt`/`val.txt` files used for actual model training are unaffected.