### PR TITLE
Accept explicit train/val paths in `generate_stats()`

### DIFF
--- a/data/processing/run_pipeline.py
+++ b/data/processing/run_pipeline.py
@@ -196,7 +196,14 @@ def run_pipeline(
     logger.info("=" * 60)
 
     try:
-        generate_stats(train_docs, val_docs, rejected_path, stats_path)
+        generate_stats(
+            train_docs,
+            val_docs,
+            rejected_path,
+            stats_path,
+            train_path=output_dir / "train.txt",
+            val_path=output_dir / "val.txt",
+        )
     except Exception as e:
         logger.error("Statistics generation failed: %s", e)
         raise

--- a/data/processing/stats.py
+++ b/data/processing/stats.py
@@ -24,6 +24,8 @@ def generate_stats(
     val_docs: list[dict],
     rejected_path: Path,
     output_path: Path,
+    train_path: Path | None = None,
+    val_path: Path | None = None,
 ) -> None:
     """Generate comprehensive corpus statistics and write to a Markdown file.
 
@@ -37,6 +39,10 @@ def generate_stats(
         val_docs: List of validation document dicts.
         rejected_path: Path to the JSONL rejection log file.
         output_path: Path to write the stats Markdown file.
+        train_path: Explicit path to train.txt. If None, defaults to
+            output_path.parent / "processed" / "train.txt".
+        val_path: Explicit path to val.txt. If None, defaults to
+            output_path.parent / "processed" / "val.txt".
     """
     all_docs = train_docs + val_docs
     total_docs = len(all_docs)
@@ -61,8 +67,16 @@ def generate_stats(
     estimated_tokens = total_chars // 4
 
     # Train/val file sizes
-    train_path = output_path.parent / "processed" / "train.txt"
-    val_path = output_path.parent / "processed" / "val.txt"
+    if train_path is None:
+        train_path = output_path.parent / "processed" / "train.txt"
+    if val_path is None:
+        val_path = output_path.parent / "processed" / "val.txt"
+
+    if not train_path.exists():
+        logger.warning("train.txt not found at %s -- file size will report 0", train_path)
+    if not val_path.exists():
+        logger.warning("val.txt not found at %s -- file size will report 0", val_path)
+
     train_size = train_path.stat().st_size if train_path.exists() else 0
     val_size = val_path.stat().st_size if val_path.exists() else 0
     total_size = train_size + val_size


### PR DESCRIPTION
## Summary

This PR adds optional `train_path` and `val_path` parameters to `generate_stats()` so file size reporting works correctly regardless of where the stats output file is placed. Missing files now produce a warning instead of silently reporting 0 bytes.

## Related issues or PRs

- Resolves issue #4

## Changes made

- Added optional `train_path` and `val_path` parameters to `generate_stats()` with backward-compatible defaults
- Added `logger.warning()` calls when train/val files are not found at the expected paths
- Updated `run_pipeline.py` to pass explicit paths derived from `output_dir`

## Technical implementation

- **Approach:** Added optional parameters with `None` defaults so existing callers (e.g., `split.py` CLI) continue to work unchanged. The fallback derivation logic is preserved for callers that don't pass explicit paths. `run_pipeline.py` now passes `output_dir / "train.txt"` and `output_dir / "val.txt"` directly, decoupling file location from the stats output path.
- **Key files modified:** `data/processing/stats.py`, `data/processing/run_pipeline.py`
- **Dependencies added/removed:** None
- **Design patterns used:** N/A

## Testing performed

- [x] Manual testing performed.

## Code quality

- [x] Code follows project conventions and patterns (PEP 8, type hints where helpful).
- [x] No hardcoded values (use constants/configuration).
- [x] Proper error handling and logging implemented.
- [x] No debugging code or print statements left in.
- [x] Removed unused imports, variables, and files.

## Additional context

Low-impact enhancement — the normal pipeline flow via `run_pipeline.py` was unaffected by the original bug since the default `stats_path` of `data/stats.md` happened to derive the correct train/val paths. This fix ensures correctness for non-standard invocations.